### PR TITLE
PCQM4Mv2 cfg to run pretrained GPS model

### DIFF
--- a/configs/GPS/pcqm4m-GPS-inference.yaml
+++ b/configs/GPS/pcqm4m-GPS-inference.yaml
@@ -1,0 +1,34 @@
+out_dir: results
+metric_best: mae
+metric_agg: argmin
+wandb:
+  use: False
+  project: scratch  # W&B project for debugging runs.
+dataset:
+  format: OGB
+  name: PCQM4Mv2-full
+  task: graph
+  task_type: regression
+  transductive: False
+  node_encoder: True
+  node_encoder_name: Atom+RWSE
+  node_encoder_bn: False
+  edge_encoder: True
+  edge_encoder_name: Bond
+  edge_encoder_bn: False
+pretrained:
+  dir: pretrained/pcqm4m-GPS+RWSE.medium
+  reset_prediction_head: False
+train:
+  mode: inference-only
+  batch_size: 256
+model:
+  type: GPSModel
+  loss_fun: l1
+  graph_pooling: mean
+gnn:
+  head: san_graph
+  layers_post_mp: 3  # Not used when `gnn.head: san_graph`
+  batchnorm: True
+  act: relu
+  dropout: 0.0


### PR DESCRIPTION
Added config file to run inference on PCQM4Mv2 using a pretrained GPS model.

To run the inference:
1. Download and unzip: https://www.dropbox.com/s/677clfz3cng8xsi/pretrained-GPS-pcqm4m.zip?dl=1
You should now have a folder `pretrained/pcqm4m-GPS+RWSE.medium` in the root of the project.
This is the last epoch checkpoint from the original run used for the GPS paper preprint. It was trained using a random split of the official `train` set to train and validation set, taking the official `valid` set as the test set. The official `test-dev` and `test-challenge` sets are not used.

2. Run: `python main.py --cfg configs/GPS/pcqm4m-GPS-inference.yaml`
Note: This will download and process the PCQM4Mv2 dataset first (~1h, when you run it for the first time), then we need to precompute Laplacian decompositions (~2h on 4 core CPU), and finally run the inference.

This checkpoint achieves `MAE: 0.0860` on what is here called the test set, which is the official `valid` set.