### PR TITLE
Graphormer and dataset extensions

### DIFF
--- a/configs/GPS/actor-GPS.yaml
+++ b/configs/GPS/actor-GPS.yaml
@@ -1,0 +1,84 @@
+out_dir: results
+metric_best: accuracy
+wandb:
+  use: True
+  project: Actor
+dataset:
+  format: PyG-Actor
+  name: none
+  task: node
+  task_type: classification
+  transductive: True
+  split_mode: standard
+  node_encoder: True
+  node_encoder_name: LapPE
+#  node_encoder_name: LinearNode+GraphormerBias
+  node_encoder_bn: False
+  edge_encoder: False
+  edge_encoder_name: DummyEdge
+  edge_encoder_bn: False
+posenc_GraphormerBias:
+  enable: False
+  node_degrees_only: True
+  num_spatial_types: 20
+  num_in_degrees: 1297
+  num_out_degrees: 74
+graphormer:
+  use_graph_token: False
+posenc_LapPE:
+  enable: True
+  eigen:
+    laplacian_norm: none
+    eigvec_norm: L2
+    max_freqs: 4
+  model: DeepSet
+  dim_pe: 4
+  layers: 2
+  n_heads: 4  # Only used when `posenc.model: Transformer`
+  raw_norm_type: none
+posenc_RWSE:
+  enable: False
+  kernel:
+    times_func: range(1,17)
+  model: Linear
+  dim_pe: 16
+  raw_norm_type: BatchNorm
+train:
+  mode: custom
+  sampler: full_batch
+#  sampler: saint_rw
+#  batch_size: 32
+  eval_period: 5
+  enable_ckpt: False
+#  ckpt_period: 100
+model:
+  type: GPSModel
+  loss_fun: cross_entropy
+  edge_decoding: dot
+gt:
+  layer_type: GCN+Transformer
+  layers: 2
+  n_heads: 4
+  dim_hidden: 64  # `gt.dim_hidden` must match `gnn.dim_inner`
+  dropout: 0.2
+  attn_dropout: 0.0
+  layer_norm: False
+  batch_norm: False
+gnn:
+  head: node
+  layers_pre_mp: 0
+  layers_post_mp: 1
+  dim_inner: 64  # `gt.dim_hidden` must match `gnn.dim_inner`
+  batchnorm: True
+  act: gelu
+  dropout: 0.2
+  agg: mean
+  normalize_adj: False
+optim:
+  clip_grad_norm: True
+  optimizer: adamW
+  weight_decay: 1e-5
+  base_lr: 0.0005
+  max_epoch: 200
+  scheduler: cosine_with_warmup
+  num_warmup_epochs: 10

--- a/configs/GPS/webkb-cor-GPS.yaml
+++ b/configs/GPS/webkb-cor-GPS.yaml
@@ -1,0 +1,84 @@
+out_dir: results
+metric_best: accuracy
+wandb:
+  use: True
+  project: Cornell
+dataset:
+  format: PyG-WebKB
+  name: cornell
+  task: node
+  task_type: classification
+  transductive: True
+  split_mode: standard
+  node_encoder: True
+  node_encoder_name: LapPE
+#  node_encoder_name: LinearNode+GraphormerBias
+  node_encoder_bn: False
+  edge_encoder: False
+  edge_encoder_name: DummyEdge
+  edge_encoder_bn: False
+posenc_GraphormerBias:
+  enable: False
+  node_degrees_only: True
+  num_spatial_types: 20
+  num_in_degrees: 9
+  num_out_degrees: 94
+graphormer:
+  use_graph_token: False
+posenc_LapPE:
+  enable: True
+  eigen:
+    laplacian_norm: none
+    eigvec_norm: L2
+    max_freqs: 4
+  model: DeepSet
+  dim_pe: 4
+  layers: 2
+  n_heads: 4  # Only used when `posenc.model: Transformer`
+  raw_norm_type: none
+posenc_RWSE:
+  enable: False
+  kernel:
+    times_func: range(1,17)
+  model: Linear
+  dim_pe: 16
+  raw_norm_type: BatchNorm
+train:
+  mode: custom
+  sampler: full_batch
+#  sampler: saint_rw
+#  batch_size: 32
+  eval_period: 5
+  enable_ckpt: False
+#  ckpt_period: 100
+model:
+  type: GPSModel
+  loss_fun: cross_entropy
+  edge_decoding: dot
+gt:
+  layer_type: GCN+Transformer
+  layers: 2
+  n_heads: 4
+  dim_hidden: 64  # `gt.dim_hidden` must match `gnn.dim_inner`
+  dropout: 0.2
+  attn_dropout: 0.0
+  layer_norm: False
+  batch_norm: False
+gnn:
+  head: node
+  layers_pre_mp: 0
+  layers_post_mp: 1
+  dim_inner: 64  # `gt.dim_hidden` must match `gnn.dim_inner`
+  batchnorm: True
+  act: gelu
+  dropout: 0.2
+  agg: mean
+  normalize_adj: False
+optim:
+  clip_grad_norm: True
+  optimizer: adamW
+  weight_decay: 1e-5
+  base_lr: 0.0005
+  max_epoch: 200
+  scheduler: cosine_with_warmup
+  num_warmup_epochs: 10

--- a/configs/GPS/webkb-tex-GPS.yaml
+++ b/configs/GPS/webkb-tex-GPS.yaml
@@ -1,0 +1,84 @@
+out_dir: results
+metric_best: accuracy
+wandb:
+  use: True
+  project: Texas
+dataset:
+  format: PyG-WebKB
+  name: texas
+  task: node
+  task_type: classification
+  transductive: True
+  split_mode: standard
+  node_encoder: True
+  node_encoder_name: LapPE
+#  node_encoder_name: LinearNode+GraphormerBias
+  node_encoder_bn: False
+  edge_encoder: False
+  edge_encoder_name: DummyEdge
+  edge_encoder_bn: False
+posenc_GraphormerBias:
+  enable: False
+  node_degrees_only: True
+  num_spatial_types: 20
+  num_in_degrees: 13
+  num_out_degrees: 105
+graphormer:
+  use_graph_token: False
+posenc_LapPE:
+  enable: True
+  eigen:
+    laplacian_norm: none
+    eigvec_norm: L2
+    max_freqs: 4
+  model: DeepSet
+  dim_pe: 4
+  layers: 2
+  n_heads: 4  # Only used when `posenc.model: Transformer`
+  raw_norm_type: none
+posenc_RWSE:
+  enable: False
+  kernel:
+    times_func: range(1,17)
+  model: Linear
+  dim_pe: 16
+  raw_norm_type: BatchNorm
+train:
+  mode: custom
+  sampler: full_batch
+#  sampler: saint_rw
+#  batch_size: 32
+  eval_period: 5
+  enable_ckpt: False
+#  ckpt_period: 100
+model:
+  type: GPSModel
+  loss_fun: cross_entropy
+  edge_decoding: dot
+gt:
+  layer_type: GCN+Transformer
+  layers: 2
+  n_heads: 4
+  dim_hidden: 64  # `gt.dim_hidden` must match `gnn.dim_inner`
+  dropout: 0.2
+  attn_dropout: 0.0
+  layer_norm: False
+  batch_norm: False
+gnn:
+  head: node
+  layers_pre_mp: 0
+  layers_post_mp: 1
+  dim_inner: 64  # `gt.dim_hidden` must match `gnn.dim_inner`
+  batchnorm: True
+  act: gelu
+  dropout: 0.2
+  agg: mean
+  normalize_adj: False
+optim:
+  clip_grad_norm: True
+  optimizer: adamW
+  weight_decay: 1e-5
+  base_lr: 0.0005
+  max_epoch: 200
+  scheduler: cosine_with_warmup
+  num_warmup_epochs: 10

--- a/configs/GPS/webkb-wis-GPS.yaml
+++ b/configs/GPS/webkb-wis-GPS.yaml
@@ -1,0 +1,84 @@
+out_dir: results
+metric_best: accuracy
+wandb:
+  use: True
+  project: Wisconsin
+dataset:
+  format: PyG-WebKB
+  name: wisconsin
+  task: node
+  task_type: classification
+  transductive: True
+  split_mode: standard
+  node_encoder: True
+  node_encoder_name: LapPE
+#  node_encoder_name: LinearNode+GraphormerBias
+  node_encoder_bn: False
+  edge_encoder: False
+  edge_encoder_name: DummyEdge
+  edge_encoder_bn: False
+posenc_GraphormerBias:
+  enable: False
+  node_degrees_only: True
+  num_spatial_types: 20
+  num_in_degrees: 12
+  num_out_degrees: 123
+graphormer:
+  use_graph_token: False
+posenc_LapPE:
+  enable: True
+  eigen:
+    laplacian_norm: none
+    eigvec_norm: L2
+    max_freqs: 4
+  model: DeepSet
+  dim_pe: 4
+  layers: 2
+  n_heads: 4  # Only used when `posenc.model: Transformer`
+  raw_norm_type: none
+posenc_RWSE:
+  enable: False
+  kernel:
+    times_func: range(1,17)
+  model: Linear
+  dim_pe: 16
+  raw_norm_type: BatchNorm
+train:
+  mode: custom
+  sampler: full_batch
+#  sampler: saint_rw
+#  batch_size: 32
+  eval_period: 5
+  enable_ckpt: False
+#  ckpt_period: 100
+model:
+  type: GPSModel
+  loss_fun: cross_entropy
+  edge_decoding: dot
+gt:
+  layer_type: GCN+Transformer
+  layers: 2
+  n_heads: 4
+  dim_hidden: 64  # `gt.dim_hidden` must match `gnn.dim_inner`
+  dropout: 0.2
+  attn_dropout: 0.0
+  layer_norm: False
+  batch_norm: False
+gnn:
+  head: node
+  layers_pre_mp: 0
+  layers_post_mp: 1
+  dim_inner: 64  # `gt.dim_hidden` must match `gnn.dim_inner`
+  batchnorm: True
+  act: gelu
+  dropout: 0.2
+  agg: mean
+  normalize_adj: False
+optim:
+  clip_grad_norm: True
+  optimizer: adamW
+  weight_decay: 1e-5
+  base_lr: 0.0005
+  max_epoch: 200
+  scheduler: cosine_with_warmup
+  num_warmup_epochs: 10

--- a/configs/GPS/wn-chameleon-GPS.yaml
+++ b/configs/GPS/wn-chameleon-GPS.yaml
@@ -1,0 +1,84 @@
+out_dir: results
+metric_best: accuracy
+wandb:
+  use: True
+  project: WN-chameleon
+dataset:
+  format: PyG-WikipediaNetwork
+  name: chameleon
+  task: node
+  task_type: classification
+  transductive: True
+  split_mode: standard
+  node_encoder: True
+  node_encoder_name: LapPE
+#  node_encoder_name: LinearNode+GraphormerBias
+  node_encoder_bn: False
+  edge_encoder: False
+  edge_encoder_name: DummyEdge
+  edge_encoder_bn: False
+posenc_GraphormerBias:
+  enable: False
+  node_degrees_only: True
+  num_spatial_types: 20
+  num_in_degrees: 729
+  num_out_degrees: 89
+graphormer:
+  use_graph_token: False
+posenc_LapPE:
+  enable: True
+  eigen:
+    laplacian_norm: none
+    eigvec_norm: L2
+    max_freqs: 4
+  model: DeepSet
+  dim_pe: 4
+  layers: 2
+  n_heads: 4  # Only used when `posenc.model: Transformer`
+  raw_norm_type: none
+posenc_RWSE:
+  enable: False
+  kernel:
+    times_func: range(1,17)
+  model: Linear
+  dim_pe: 16
+  raw_norm_type: BatchNorm
+train:
+  mode: custom
+  sampler: full_batch
+#  sampler: saint_rw
+#  batch_size: 32
+  eval_period: 5
+  enable_ckpt: False
+#  ckpt_period: 100
+model:
+  type: GPSModel
+  loss_fun: cross_entropy
+  edge_decoding: dot
+gt:
+  layer_type: GCN+Transformer
+  layers: 3
+  n_heads: 4
+  dim_hidden: 96  # `gt.dim_hidden` must match `gnn.dim_inner`
+  dropout: 0.2
+  attn_dropout: 0.5
+  layer_norm: False
+  batch_norm: False
+gnn:
+  head: node
+  layers_pre_mp: 0
+  layers_post_mp: 1
+  dim_inner: 96  # `gt.dim_hidden` must match `gnn.dim_inner`
+  batchnorm: True
+  act: gelu
+  dropout: 0.2
+  agg: mean
+  normalize_adj: False
+optim:
+  clip_grad_norm: True
+  optimizer: adamW
+  weight_decay: 1e-5
+  base_lr: 0.0005
+  max_epoch: 200
+  scheduler: cosine_with_warmup
+  num_warmup_epochs: 10

--- a/configs/GPS/wn-squirrel-GPS.yaml
+++ b/configs/GPS/wn-squirrel-GPS.yaml
@@ -1,0 +1,84 @@
+out_dir: results
+metric_best: accuracy
+wandb:
+  use: True
+  project: WN-squirrel
+dataset:
+  format: PyG-WikipediaNetwork
+  name: squirrel
+  task: node
+  task_type: classification
+  transductive: True
+  split_mode: standard
+  node_encoder: True
+  node_encoder_name: LapPE
+#  node_encoder_name: LinearNode+GraphormerBias
+  node_encoder_bn: False
+  edge_encoder: False
+  edge_encoder_name: DummyEdge
+  edge_encoder_bn: False
+posenc_GraphormerBias:
+  enable: False
+  node_degrees_only: True
+  num_spatial_types: 20
+  num_in_degrees: 1885
+  num_out_degrees: 265
+graphormer:
+  use_graph_token: False
+posenc_LapPE:
+  enable: True
+  eigen:
+    laplacian_norm: none
+    eigvec_norm: L2
+    max_freqs: 4
+  model: DeepSet
+  dim_pe: 4
+  layers: 2
+  n_heads: 4  # Only used when `posenc.model: Transformer`
+  raw_norm_type: none
+posenc_RWSE:
+  enable: False
+  kernel:
+    times_func: range(1,17)
+  model: Linear
+  dim_pe: 16
+  raw_norm_type: BatchNorm
+train:
+  mode: custom
+  sampler: full_batch
+#  sampler: saint_rw
+#  batch_size: 32
+  eval_period: 5
+  enable_ckpt: False
+#  ckpt_period: 100
+model:
+  type: GPSModel
+  loss_fun: cross_entropy
+  edge_decoding: dot
+gt:
+  layer_type: GCN+Transformer
+  layers: 2
+  n_heads: 4
+  dim_hidden: 64  # `gt.dim_hidden` must match `gnn.dim_inner`
+  dropout: 0.2
+  attn_dropout: 0.0
+  layer_norm: False
+  batch_norm: False
+gnn:
+  head: node
+  layers_pre_mp: 0
+  layers_post_mp: 1
+  dim_inner: 64  # `gt.dim_hidden` must match `gnn.dim_inner`
+  batchnorm: True
+  act: gelu
+  dropout: 0.2
+  agg: mean
+  normalize_adj: False
+optim:
+  clip_grad_norm: True
+  optimizer: adamW
+  weight_decay: 1e-5
+  base_lr: 0.0005
+  max_epoch: 200
+  scheduler: cosine_with_warmup
+  num_warmup_epochs: 10

--- a/configs/GPS/zinc-GPSwGraphormer+VN.yaml
+++ b/configs/GPS/zinc-GPSwGraphormer+VN.yaml
@@ -1,0 +1,65 @@
+out_dir: results
+metric_best: mae
+metric_agg: argmin
+wandb:
+  use: True
+  project: ZINC
+dataset:
+  format: PyG-ZINC
+  name: subset
+  task: graph
+  task_type: regression
+  transductive: False
+  node_encoder: True
+  node_encoder_name: TypeDictNode+GraphormerBias
+  node_encoder_num_types: 28
+  node_encoder_bn: False
+  edge_encoder: True
+  edge_encoder_name: TypeDictEdge
+  edge_encoder_num_types: 4
+  edge_encoder_bn: False
+posenc_GraphormerBias:
+  enable: True
+  node_degrees_only: False
+  num_spatial_types: 20
+  num_in_degrees: 64
+  num_out_degrees: 64
+graphormer:
+  use_graph_token: True  # Add Virtual Node (VN) for global graph representation; does not work with other PE/SE such as LapPE or RWSE
+train:
+  mode: custom
+  batch_size: 32
+  eval_period: 1
+  ckpt_period: 100
+model:
+  type: GPSModel
+  loss_fun: l1
+  edge_decoding: dot
+  graph_pooling: graph_token
+gt:
+  layer_type: GINE+BiasedTransformer  # CustomGatedGCN+Performer
+  layers: 10
+  n_heads: 4
+  dim_hidden: 64  # `gt.dim_hidden` must match `gnn.dim_inner`
+  dropout: 0.0
+  attn_dropout: 0.5
+  layer_norm: False
+  batch_norm: True
+gnn:
+  head: san_graph  # or `graphormer_graph`
+  layers_pre_mp: 0
+  layers_post_mp: 3  # Not used when `gnn.head: san_graph`
+  dim_inner: 64  # `gt.dim_hidden` must match `gnn.dim_inner`
+  batchnorm: True
+  act: relu
+  dropout: 0.0
+  agg: mean
+  normalize_adj: False
+optim:
+  clip_grad_norm: True
+  optimizer: adamW
+  weight_decay: 1e-5
+  base_lr: 0.001
+  max_epoch: 2000
+  scheduler: cosine_with_warmup
+  num_warmup_epochs: 50

--- a/configs/GPS/zinc-GPSwGraphormer.yaml
+++ b/configs/GPS/zinc-GPSwGraphormer.yaml
@@ -1,0 +1,83 @@
+out_dir: results
+metric_best: mae
+metric_agg: argmin
+wandb:
+  use: True
+  project: ZINC
+dataset:
+  format: PyG-ZINC
+  name: subset
+  task: graph
+  task_type: regression
+  transductive: False
+  node_encoder: True
+#  node_encoder_name: TypeDictNode+GraphormerBias+LapPE
+  node_encoder_name: TypeDictNode+GraphormerBias+RWSE
+  node_encoder_num_types: 28
+  node_encoder_bn: False
+  edge_encoder: True
+  edge_encoder_name: TypeDictEdge
+  edge_encoder_num_types: 4
+  edge_encoder_bn: False
+posenc_GraphormerBias:
+  enable: True
+  node_degrees_only: False
+  num_spatial_types: 20
+  num_in_degrees: 64
+  num_out_degrees: 64
+graphormer:
+  use_graph_token: False
+posenc_LapPE:
+  enable: False
+  eigen:
+    laplacian_norm: none
+    eigvec_norm: L2
+    max_freqs: 8
+  model: DeepSet
+  dim_pe: 8
+  layers: 2
+  raw_norm_type: none
+posenc_RWSE:
+  enable: True
+  kernel:
+    times_func: range(1,21)
+  model: Linear
+  dim_pe: 28
+  raw_norm_type: BatchNorm
+train:
+  mode: custom
+  batch_size: 32
+  eval_period: 1
+  ckpt_period: 100
+model:
+  type: GPSModel
+  loss_fun: l1
+  edge_decoding: dot
+  graph_pooling: add
+gt:
+  layer_type: GINE+BiasedTransformer  # CustomGatedGCN+Performer
+  layers: 10
+  n_heads: 4
+  dim_hidden: 64  # `gt.dim_hidden` must match `gnn.dim_inner`
+  dropout: 0.0
+  attn_dropout: 0.5
+  layer_norm: False
+  batch_norm: True
+gnn:
+  head: san_graph
+  layers_pre_mp: 0
+  layers_post_mp: 3  # Not used when `gnn.head: san_graph`
+  dim_inner: 64  # `gt.dim_hidden` must match `gnn.dim_inner`
+  batchnorm: True
+  act: relu
+  dropout: 0.0
+  agg: mean
+  normalize_adj: False
+optim:
+  clip_grad_norm: True
+  optimizer: adamW
+  weight_decay: 1e-5
+  base_lr: 0.001
+  max_epoch: 2000
+  scheduler: cosine_with_warmup
+  num_warmup_epochs: 50

--- a/configs/Graphormer/actor-Graphormer.yaml
+++ b/configs/Graphormer/actor-Graphormer.yaml
@@ -1,0 +1,63 @@
+out_dir: results
+metric_best: accuracy
+wandb:
+  use: True
+  project: Actor
+dataset:
+  format: PyG-Actor
+  name: none
+  task: node
+  task_type: classification
+  transductive: True
+  split_mode: standard
+  node_encoder: True
+  node_encoder_name: LinearNode+GraphormerBias
+  node_encoder_bn: False
+  edge_encoder: False
+  edge_encoder_name: DummyEdge
+  edge_encoder_bn: False
+posenc_GraphormerBias:
+  enable: True
+  num_spatial_types: 20
+  num_in_degrees: 1297
+  num_out_degrees: 74
+train:
+  mode: custom
+  sampler: full_batch
+#  sampler: saint_rw
+#  batch_size: 32
+  eval_period: 5
+  enable_ckpt: False
+#  ckpt_period: 100
+model:
+  type: Graphormer
+  loss_fun: cross_entropy
+  edge_decoding: dot
+graphormer:
+  use_graph_token: False
+  num_layers: 2
+  num_heads: 4
+  embed_dim: 64  # `graphormer.embed_dim` must match `gnn.dim_inner`
+  dropout: 0.2
+  attention_dropout: 0.0
+  mlp_dropout: 0.2
+  input_dropout: 0.0
+gnn:
+  head: node
+  layers_pre_mp: 0
+  layers_post_mp: 1
+  dim_inner: 64  # `gt.dim_hidden` must match `gnn.dim_inner`
+  batchnorm: True
+  act: gelu
+  dropout: 0.2
+  agg: mean
+  normalize_adj: False
+optim:
+  clip_grad_norm: True
+  clip_grad_norm_value: 5.0
+  optimizer: adamW
+  weight_decay: 1e-5
+  base_lr: 0.0005
+  max_epoch: 200
+  scheduler: cosine_with_warmup
+  num_warmup_epochs: 10

--- a/configs/Graphormer/webkb-cor-Graphormer.yaml
+++ b/configs/Graphormer/webkb-cor-Graphormer.yaml
@@ -1,0 +1,63 @@
+out_dir: results
+metric_best: accuracy
+wandb:
+  use: True
+  project: Cornell
+dataset:
+  format: PyG-WebKB
+  name: cornell
+  task: node
+  task_type: classification
+  transductive: True
+  split_mode: standard
+  node_encoder: True
+  node_encoder_name: LinearNode+GraphormerBias
+  node_encoder_bn: False
+  edge_encoder: False
+  edge_encoder_name: DummyEdge
+  edge_encoder_bn: False
+posenc_GraphormerBias:
+  enable: True
+  num_spatial_types: 20
+  num_in_degrees: 9
+  num_out_degrees: 94
+train:
+  mode: custom
+  sampler: full_batch
+#  sampler: saint_rw
+#  batch_size: 32
+  eval_period: 5
+  enable_ckpt: False
+#  ckpt_period: 100
+model:
+  type: Graphormer
+  loss_fun: cross_entropy
+  edge_decoding: dot
+graphormer:
+  use_graph_token: False
+  num_layers: 2
+  num_heads: 4
+  embed_dim: 64  # `graphormer.embed_dim` must match `gnn.dim_inner`
+  dropout: 0.2
+  attention_dropout: 0.0
+  mlp_dropout: 0.2
+  input_dropout: 0.0
+gnn:
+  head: node
+  layers_pre_mp: 0
+  layers_post_mp: 1
+  dim_inner: 64  # `gt.dim_hidden` must match `gnn.dim_inner`
+  batchnorm: True
+  act: gelu
+  dropout: 0.2
+  agg: mean
+  normalize_adj: False
+optim:
+  clip_grad_norm: True
+  clip_grad_norm_value: 5.0
+  optimizer: adamW
+  weight_decay: 1e-5
+  base_lr: 0.0005
+  max_epoch: 200
+  scheduler: cosine_with_warmup
+  num_warmup_epochs: 10

--- a/configs/Graphormer/webkb-tex-Graphormer.yaml
+++ b/configs/Graphormer/webkb-tex-Graphormer.yaml
@@ -1,0 +1,63 @@
+out_dir: results
+metric_best: accuracy
+wandb:
+  use: True
+  project: Texas
+dataset:
+  format: PyG-WebKB
+  name: texas
+  task: node
+  task_type: classification
+  transductive: True
+  split_mode: standard
+  node_encoder: True
+  node_encoder_name: LinearNode+GraphormerBias
+  node_encoder_bn: False
+  edge_encoder: False
+  edge_encoder_name: DummyEdge
+  edge_encoder_bn: False
+posenc_GraphormerBias:
+  enable: True
+  num_spatial_types: 20
+  num_in_degrees: 13
+  num_out_degrees: 105
+train:
+  mode: custom
+  sampler: full_batch
+#  sampler: saint_rw
+#  batch_size: 32
+  eval_period: 5
+  enable_ckpt: False
+#  ckpt_period: 100
+model:
+  type: Graphormer
+  loss_fun: cross_entropy
+  edge_decoding: dot
+graphormer:
+  use_graph_token: False
+  num_layers: 2
+  num_heads: 4
+  embed_dim: 64  # `graphormer.embed_dim` must match `gnn.dim_inner`
+  dropout: 0.2
+  attention_dropout: 0.0
+  mlp_dropout: 0.2
+  input_dropout: 0.0
+gnn:
+  head: node
+  layers_pre_mp: 0
+  layers_post_mp: 1
+  dim_inner: 64  # `gt.dim_hidden` must match `gnn.dim_inner`
+  batchnorm: True
+  act: gelu
+  dropout: 0.2
+  agg: mean
+  normalize_adj: False
+optim:
+  clip_grad_norm: True
+  clip_grad_norm_value: 5.0
+  optimizer: adamW
+  weight_decay: 1e-5
+  base_lr: 0.0005
+  max_epoch: 200
+  scheduler: cosine_with_warmup
+  num_warmup_epochs: 10

--- a/configs/Graphormer/webkb-wis-Graphormer.yaml
+++ b/configs/Graphormer/webkb-wis-Graphormer.yaml
@@ -1,0 +1,63 @@
+out_dir: results
+metric_best: accuracy
+wandb:
+  use: True
+  project: Wisconsin
+dataset:
+  format: PyG-WebKB
+  name: wisconsin
+  task: node
+  task_type: classification
+  transductive: True
+  split_mode: standard
+  node_encoder: True
+  node_encoder_name: LinearNode+GraphormerBias
+  node_encoder_bn: False
+  edge_encoder: False
+  edge_encoder_name: DummyEdge
+  edge_encoder_bn: False
+posenc_GraphormerBias:
+  enable: True
+  num_spatial_types: 20
+  num_in_degrees: 12
+  num_out_degrees: 123
+train:
+  mode: custom
+  sampler: full_batch
+#  sampler: saint_rw
+#  batch_size: 32
+  eval_period: 5
+  enable_ckpt: False
+#  ckpt_period: 100
+model:
+  type: Graphormer
+  loss_fun: cross_entropy
+  edge_decoding: dot
+graphormer:
+  use_graph_token: False
+  num_layers: 2
+  num_heads: 4
+  embed_dim: 64  # `graphormer.embed_dim` must match `gnn.dim_inner`
+  dropout: 0.2
+  attention_dropout: 0.0
+  mlp_dropout: 0.2
+  input_dropout: 0.0
+gnn:
+  head: node
+  layers_pre_mp: 0
+  layers_post_mp: 1
+  dim_inner: 64  # `gt.dim_hidden` must match `gnn.dim_inner`
+  batchnorm: True
+  act: gelu
+  dropout: 0.2
+  agg: mean
+  normalize_adj: False
+optim:
+  clip_grad_norm: True
+  clip_grad_norm_value: 5.0
+  optimizer: adamW
+  weight_decay: 1e-5
+  base_lr: 0.0005
+  max_epoch: 200
+  scheduler: cosine_with_warmup
+  num_warmup_epochs: 10

--- a/configs/Graphormer/wn-chameleon-Graphormer.yaml
+++ b/configs/Graphormer/wn-chameleon-Graphormer.yaml
@@ -1,0 +1,63 @@
+out_dir: results
+metric_best: accuracy
+wandb:
+  use: True
+  project: WN-chameleon
+dataset:
+  format: PyG-WikipediaNetwork
+  name: chameleon
+  task: node
+  task_type: classification
+  transductive: True
+  split_mode: standard
+  node_encoder: True
+  node_encoder_name: LinearNode+GraphormerBias
+  node_encoder_bn: False
+  edge_encoder: False
+  edge_encoder_name: DummyEdge
+  edge_encoder_bn: False
+posenc_GraphormerBias:
+  enable: True
+  num_spatial_types: 20
+  num_in_degrees: 729
+  num_out_degrees: 89
+train:
+  mode: custom
+  sampler: full_batch
+#  sampler: saint_rw
+#  batch_size: 32
+  eval_period: 5
+  enable_ckpt: False
+#  ckpt_period: 100
+model:
+  type: Graphormer
+  loss_fun: cross_entropy
+  edge_decoding: dot
+graphormer:
+  use_graph_token: False
+  num_layers: 2
+  num_heads: 4
+  embed_dim: 64  # `graphormer.embed_dim` must match `gnn.dim_inner`
+  dropout: 0.2
+  attention_dropout: 0.0
+  mlp_dropout: 0.2
+  input_dropout: 0.0
+gnn:
+  head: node
+  layers_pre_mp: 0
+  layers_post_mp: 1
+  dim_inner: 64  # `gt.dim_hidden` must match `gnn.dim_inner`
+  batchnorm: True
+  act: gelu
+  dropout: 0.2
+  agg: mean
+  normalize_adj: False
+optim:
+  clip_grad_norm: True
+  clip_grad_norm_value: 5.0
+  optimizer: adamW
+  weight_decay: 1e-5
+  base_lr: 0.0005
+  max_epoch: 200
+  scheduler: cosine_with_warmup
+  num_warmup_epochs: 10

--- a/configs/Graphormer/wn-squirrel-Graphormer.yaml
+++ b/configs/Graphormer/wn-squirrel-Graphormer.yaml
@@ -1,0 +1,63 @@
+out_dir: results
+metric_best: accuracy
+wandb:
+  use: True
+  project: WN-squirrel
+dataset:
+  format: PyG-WikipediaNetwork
+  name: squirrel
+  task: node
+  task_type: classification
+  transductive: True
+  split_mode: standard
+  node_encoder: True
+  node_encoder_name: LinearNode+GraphormerBias
+  node_encoder_bn: False
+  edge_encoder: False
+  edge_encoder_name: DummyEdge
+  edge_encoder_bn: False
+posenc_GraphormerBias:
+  enable: True
+  num_spatial_types: 20
+  num_in_degrees: 1885
+  num_out_degrees: 265
+train:
+  mode: custom
+  sampler: full_batch
+#  sampler: saint_rw
+#  batch_size: 32
+  eval_period: 5
+  enable_ckpt: False
+#  ckpt_period: 100
+model:
+  type: Graphormer
+  loss_fun: cross_entropy
+  edge_decoding: dot
+graphormer:
+  use_graph_token: False
+  num_layers: 2
+  num_heads: 4
+  embed_dim: 64  # `graphormer.embed_dim` must match `gnn.dim_inner`
+  dropout: 0.2
+  attention_dropout: 0.0
+  mlp_dropout: 0.2
+  input_dropout: 0.0
+gnn:
+  head: node
+  layers_pre_mp: 0
+  layers_post_mp: 1
+  dim_inner: 64  # `gt.dim_hidden` must match `gnn.dim_inner`
+  batchnorm: True
+  act: gelu
+  dropout: 0.2
+  agg: mean
+  normalize_adj: False
+optim:
+  clip_grad_norm: True
+  clip_grad_norm_value: 5.0
+  optimizer: adamW
+  weight_decay: 1e-5
+  base_lr: 0.0005
+  max_epoch: 200
+  scheduler: cosine_with_warmup
+  num_warmup_epochs: 10

--- a/configs/Graphormer/zinc-Graphormer.yaml
+++ b/configs/Graphormer/zinc-Graphormer.yaml
@@ -1,0 +1,62 @@
+out_dir: results
+metric_best: mae
+metric_agg: argmin
+wandb:
+  use: False
+  project: ZINC
+dataset:
+  format: PyG-ZINC
+  name: subset
+  task: graph
+  task_type: regression
+  transductive: False
+  node_encoder: True
+  node_encoder_name: TypeDictNode+GraphormerBias
+  node_encoder_num_types: 28
+  node_encoder_bn: False
+  edge_encoder: False
+  edge_encoder_name: TypeDictEdge
+  edge_encoder_num_types: 4
+  edge_encoder_bn: False
+posenc_GraphormerBias:
+  enable: True
+  node_degrees_only: False
+  num_spatial_types: 20
+  num_in_degrees: 64
+  num_out_degrees: 64
+train:
+  mode: custom
+  batch_size: 256
+  eval_period: 1
+  ckpt_period: 100
+model:
+  type: Graphormer
+  loss_fun: l1
+  edge_decoding: dot
+  graph_pooling: graph_token
+graphormer:
+  num_layers: 12
+  num_heads: 8
+  embed_dim: 80
+  dropout: 0.0
+  attention_dropout: 0.1
+  mlp_dropout: 0.1
+  input_dropout: 0.1
+gnn:
+  head: graphormer_graph
+  layers_pre_mp: 0
+  layers_post_mp: 3  # Not used when `gnn.head: san_graph`
+  dim_inner: 80  # `gt.dim_hidden` must match `gnn.dim_inner`
+  batchnorm: True
+  act: relu
+  dropout: 0.0
+  agg: mean
+  normalize_adj: False
+optim:
+  clip_grad_norm: True
+  clip_grad_norm_value: 5.0
+  optimizer: adamW
+  weight_decay: 0.01
+  base_lr: 0.001 # 0.0002
+  max_epoch: 5000 # 10000
+  scheduler: polynomial_with_warmup

--- a/graphgps/config/dataset_config.py
+++ b/graphgps/config/dataset_config.py
@@ -14,3 +14,6 @@ def dataset_cfg(cfg):
 
     # VOC/COCO Superpixels dataset version based on SLIC compactness parameter.
     cfg.dataset.slic_compactness = 10
+
+    # infer-link parameters (e.g., edge prediction task)
+    cfg.dataset.infer_link_label = "None"

--- a/graphgps/config/graphormer_config.py
+++ b/graphgps/config/graphormer_config.py
@@ -1,0 +1,23 @@
+from torch_geometric.graphgym.register import register_config
+from yacs.config import CfgNode as CN
+
+
+@register_config('cfg_graphormer')
+def set_cfg_gt(cfg):
+    cfg.graphormer = CN()
+    cfg.graphormer.num_layers = 6
+    cfg.graphormer.embed_dim = 80
+    cfg.graphormer.num_heads = 4
+    cfg.graphormer.dropout = 0.0
+    cfg.graphormer.attention_dropout = 0.0
+    cfg.graphormer.mlp_dropout = 0.0
+    cfg.graphormer.input_dropout = 0.0
+    cfg.graphormer.use_graph_token = True
+
+    cfg.posenc_GraphormerBias = CN()
+    cfg.posenc_GraphormerBias.enable = False
+    cfg.posenc_GraphormerBias.node_degrees_only = False
+    cfg.posenc_GraphormerBias.dim_pe = 0
+    cfg.posenc_GraphormerBias.num_spatial_types = None
+    cfg.posenc_GraphormerBias.num_in_degrees = None
+    cfg.posenc_GraphormerBias.num_out_degrees = None

--- a/graphgps/config/optimizers_config.py
+++ b/graphgps/config/optimizers_config.py
@@ -25,3 +25,4 @@ def extended_optim_cfg(cfg):
 
     # Clip gradient norms while training
     cfg.optim.clip_grad_norm = False
+    cfg.optim.clip_grad_norm_value = 1.0

--- a/graphgps/encoder/graphormer_encoder.py
+++ b/graphgps/encoder/graphormer_encoder.py
@@ -1,0 +1,275 @@
+import networkx as nx
+import torch
+import torch.nn.functional as F
+from torch_geometric.graphgym.config import cfg
+from torch_geometric.graphgym.register import register_node_encoder
+from torch_geometric.utils import to_dense_adj, to_networkx
+
+# Permutes from (batch, node, node, head) to (batch, head, node, node)
+BATCH_HEAD_NODE_NODE = (0, 3, 1, 2)
+
+# Inserts a leading 0 row and a leading 0 column with F.pad
+INSERT_GRAPH_TOKEN = (1, 0, 1, 0)
+
+
+def graphormer_pre_processing(data, distance):
+    """Implementation of Graphormer pre-processing. Computes in- and out-degrees
+    for node encodings, as well as spatial types (via shortest-path lengths) and
+    prepares edge encodings along shortest paths. The function adds the following
+    properties to the data object:
+
+    - spatial_types
+    - graph_index: An edge_index type tensor that contains all possible directed edges 
+                  (see more below)
+    - shortest_path_types: Populates edge attributes along all shortest paths between two nodes
+
+    Similar to the adjacency matrix, any matrix can be batched in PyG by decomposing it
+    into a 1D tensor of values and a 2D tensor of indices. Once batched, the graph-specific
+    matrix can be recovered (while appropriately padded) via ``to_dense_adj``. We use this 
+    concept to decompose the spatial type matrix and the shortest path edge type tensor
+    via the ``graph_index`` tensor.
+
+    Args:
+        data: A PyG data object holding a single graph
+        distance: The distance up to which types are calculated
+
+    Returns:
+        The augmented data object.
+    """
+    graph: nx.DiGraph = to_networkx(data)
+
+    data.in_degrees = torch.tensor([d for _, d in graph.in_degree()])
+    data.out_degrees = torch.tensor([d for _, d in graph.out_degree()])
+
+    max_in_degree = torch.max(data.in_degrees)
+    max_out_degree = torch.max(data.out_degrees)
+    if max_in_degree >= cfg.posenc_GraphormerBias.num_in_degrees:
+        raise ValueError(
+            f"Encountered in_degree: {max_in_degree}, set posenc_"
+            f"GraphormerBias.num_in_degrees to at least {max_in_degree + 1}"
+        )
+    if max_out_degree >= cfg.posenc_GraphormerBias.num_out_degrees:
+        raise ValueError(
+            f"Encountered out_degree: {max_out_degree}, set posenc_"
+            f"GraphormerBias.num_out_degrees to at least {max_out_degree + 1}"
+        )
+
+    if cfg.posenc_GraphormerBias.node_degrees_only:
+        return data
+
+    N = len(graph.nodes)
+    shortest_paths = nx.shortest_path(graph)
+
+    spatial_types = torch.empty(N ** 2, dtype=torch.long).fill_(distance)
+    graph_index = torch.empty(2, N ** 2, dtype=torch.long)
+
+    if hasattr(data, "edge_attr") and data.edge_attr is not None:
+        shortest_path_types = torch.zeros(N ** 2, distance, dtype=torch.long)
+        edge_attr = torch.zeros(N, N, dtype=torch.long)
+        edge_attr[data.edge_index[0], data.edge_index[1]] = data.edge_attr
+
+    for i in range(N):
+        for j in range(N):
+            graph_index[0, i * N + j] = i
+            graph_index[1, i * N + j] = j
+
+    for i, paths in shortest_paths.items():
+        for j, path in paths.items():
+            if len(path) > distance:
+                path = path[:distance]
+
+            assert len(path) >= 1
+            spatial_types[i * N + j] = len(path) - 1
+
+            if len(path) > 1 and hasattr(data, "edge_attr") and data.edge_attr is not None:
+                path_attr = [
+                    edge_attr[path[k], path[k + 1]] for k in
+                    range(len(path) - 1)  # len(path) * (num_edge_types)
+                ]
+
+                # We map each edge-encoding-distance pair to a distinct value
+                # and so obtain dist * num_edge_features many encodings
+                shortest_path_types[i * N + j, :len(path) - 1] = torch.tensor(
+                    path_attr, dtype=torch.long)
+
+    data.spatial_types = spatial_types
+    data.graph_index = graph_index
+
+    if hasattr(data, "edge_attr") and data.edge_attr is not None:
+        data.shortest_path_types = shortest_path_types
+    return data
+
+
+class BiasEncoder(torch.nn.Module):
+    def __init__(self, num_heads: int, num_spatial_types: int,
+                 num_edge_types: int, use_graph_token: bool = True):
+        """Implementation of the bias encoder of Graphormer.
+        This encoder is based on the implementation at:
+        https://github.com/microsoft/Graphormer/tree/v1.0
+        Note that this refers to v1 of Graphormer.
+
+        Args:
+            num_heads: The number of heads of the Graphormer model
+            num_spatial_types: The total number of different spatial types
+            num_edge_types: The total number of different edge types
+            use_graph_token: If True, pads the attn_bias to account for the
+            additional graph token that can be added by the ``NodeEncoder``.
+        """
+        super().__init__()
+        self.num_heads = num_heads
+
+        # Takes into account disconnected nodes
+        self.spatial_encoder = torch.nn.Embedding(
+            num_spatial_types + 1, num_heads)
+        self.edge_dis_encoder = torch.nn.Embedding(
+            num_spatial_types * num_heads * num_heads, 1)
+        self.edge_encoder = torch.nn.Embedding(num_edge_types, num_heads)
+
+        self.use_graph_token = use_graph_token
+        if self.use_graph_token:
+            self.graph_token = torch.nn.Parameter(torch.zeros(1, num_heads, 1))
+        self.reset_parameters()
+
+    def reset_parameters(self):
+        self.spatial_encoder.weight.data.normal_(std=0.02)
+        self.edge_encoder.weight.data.normal_(std=0.02)
+        self.edge_dis_encoder.weight.data.normal_(std=0.02)
+        if self.use_graph_token:
+            self.graph_token.data.normal_(std=0.02)
+
+    def forward(self, data):
+        """Computes the bias matrix that can be induced into multi-head attention
+        via the attention mask.
+
+        Adds the tensor ``attn_bias`` to the data object, optionally accounting
+        for the graph token.
+        """
+        # To convert 2D matrices to dense-batch mode, one needs to decompose
+        # them into index and value. One example is the adjacency matrix
+        # but this generalizes actually to any 2D matrix
+        spatial_types: torch.Tensor = self.spatial_encoder(data.spatial_types)
+        spatial_encodings = to_dense_adj(data.graph_index,
+                                         data.batch,
+                                         spatial_types)
+        bias = spatial_encodings.permute(BATCH_HEAD_NODE_NODE)
+
+        if hasattr(data, "shortest_path_types"):
+            edge_types: torch.Tensor = self.edge_encoder(
+                data.shortest_path_types)
+            edge_encodings = to_dense_adj(data.graph_index,
+                                          data.batch,
+                                          edge_types)
+
+            spatial_distances = to_dense_adj(data.graph_index,
+                                             data.batch,
+                                             data.spatial_types)
+            spatial_distances = spatial_distances.float().clamp(min=1.0).unsqueeze(1)
+
+            B, N, _, max_dist, H = edge_encodings.shape
+
+            edge_encodings = edge_encodings.permute(3, 0, 1, 2, 4).reshape(max_dist, -1, self.num_heads)
+            edge_encodings = torch.bmm(edge_encodings, self.edge_dis_encoder.weight.reshape(-1, self.num_heads, self.num_heads))
+            edge_encodings = edge_encodings.reshape(max_dist, B, N, N, self.num_heads).permute(1, 2, 3, 0, 4)
+            edge_encodings = edge_encodings.sum(-2).permute(BATCH_HEAD_NODE_NODE) / spatial_distances
+            bias += edge_encodings
+
+        if self.use_graph_token:
+            bias = F.pad(bias, INSERT_GRAPH_TOKEN)
+            bias[:, :, 1:, 0] = self.graph_token
+            bias[:, :, 0, :] = self.graph_token
+
+        B, H, N, _ = bias.shape
+        data.attn_bias = bias.reshape(B * H, N, N)
+        return data
+
+
+def add_graph_token(data, token):
+    """Helper function to augment a batch of PyG graphs
+    with a graph token each. Note that the token is
+    automatically replicated to fit the batch.
+
+    Args:
+        data: A PyG data object holding a single graph
+        token: A tensor containing the graph token values
+
+    Returns:
+        The augmented data object.
+    """
+    B = len(data.batch.unique())
+    tokens = torch.repeat_interleave(token, B, 0)
+    data.x = torch.cat([tokens, data.x], 0)
+    data.batch = torch.cat(
+        [torch.arange(0, B, device=data.x.device, dtype=torch.long), data.batch]
+    )
+    data.batch, sort_idx = torch.sort(data.batch)
+    data.x = data.x[sort_idx]
+    return data
+
+
+class NodeEncoder(torch.nn.Module):
+    def __init__(self, embed_dim, num_in_degree, num_out_degree,
+                 input_dropout=0.0, use_graph_token: bool = True):
+        """Implementation of the node encoder of Graphormer.
+        This encoder is based on the implementation at:
+        https://github.com/microsoft/Graphormer/tree/v1.0
+        Note that this refers to v1 of Graphormer.
+
+        Args:
+            embed_dim: The number of hidden dimensions of the model
+            num_in_degree: Maximum size of in-degree to encode
+            num_out_degree: Maximum size of out-degree to encode
+            input_dropout: Dropout applied to the input features
+            use_graph_token: If True, adds the graph token to the incoming batch.
+        """
+        super().__init__()
+        self.in_degree_encoder = torch.nn.Embedding(num_in_degree, embed_dim)
+        self.out_degree_encoder = torch.nn.Embedding(num_out_degree, embed_dim)
+
+        self.use_graph_token = use_graph_token
+        if self.use_graph_token:
+            self.graph_token = torch.nn.Parameter(torch.zeros(1, embed_dim))
+        self.input_dropout = torch.nn.Dropout(input_dropout)
+        self.reset_parameters()
+
+    def forward(self, data):
+        in_degree_encoding = self.in_degree_encoder(data.in_degrees)
+        out_degree_encoding = self.out_degree_encoder(data.out_degrees)
+
+        if data.x.size(1) > 0:
+            data.x = data.x + in_degree_encoding + out_degree_encoding
+        else:
+            data.x = in_degree_encoding + out_degree_encoding
+
+        if self.use_graph_token:
+            data = add_graph_token(data, self.graph_token)
+        data.x = self.input_dropout(data.x)
+        return data
+
+    def reset_parameters(self):
+        self.in_degree_encoder.weight.data.normal_(std=0.02)
+        self.out_degree_encoder.weight.data.normal_(std=0.02)
+        if self.use_graph_token:
+            self.graph_token.data.normal_(std=0.02)
+
+
+@register_node_encoder("GraphormerBias")
+class GraphormerEncoder(torch.nn.Sequential):
+    def __init__(self, dim_emb, *args, **kwargs):
+        encoders = [
+            BiasEncoder(
+                cfg.graphormer.num_heads,
+                cfg.posenc_GraphormerBias.num_spatial_types,
+                cfg.dataset.edge_encoder_num_types,
+                cfg.graphormer.use_graph_token
+            ),
+            NodeEncoder(
+                dim_emb,
+                cfg.posenc_GraphormerBias.num_in_degrees,
+                cfg.posenc_GraphormerBias.num_out_degrees,
+                cfg.graphormer.input_dropout,
+                cfg.graphormer.use_graph_token
+            ),
+        ]
+        if cfg.posenc_GraphormerBias.node_degrees_only:  # No attn. bias encoder
+            encoders = encoders[1:]
+        super().__init__(*encoders)

--- a/graphgps/encoder/kernel_pos_encoder.py
+++ b/graphgps/encoder/kernel_pos_encoder.py
@@ -42,13 +42,13 @@ class KernelPENodeEncoder(torch.nn.Module):
         norm_type = pecfg.raw_norm_type.lower()  # Raw PE normalization layer type
         self.pass_as_var = pecfg.pass_as_var  # Pass PE also as a separate variable
 
-        if dim_emb - dim_pe < 1:
+        if dim_emb - dim_pe < 0: # formerly 1, but you could have zero feature size
             raise ValueError(f"PE dim size {dim_pe} is too large for "
                              f"desired embedding size of {dim_emb}.")
 
-        if expand_x:
+        if expand_x and dim_emb - dim_pe > 0:
             self.linear_x = nn.Linear(dim_in, dim_emb - dim_pe)
-        self.expand_x = expand_x
+        self.expand_x = expand_x and dim_emb - dim_pe > 0
 
         if norm_type == 'batchnorm':
             self.raw_norm = nn.BatchNorm1d(num_rw_steps)

--- a/graphgps/encoder/laplace_pos_encoder.py
+++ b/graphgps/encoder/laplace_pos_encoder.py
@@ -35,13 +35,13 @@ class LapPENodeEncoder(torch.nn.Module):
         norm_type = pecfg.raw_norm_type.lower()  # Raw PE normalization layer type
         self.pass_as_var = pecfg.pass_as_var  # Pass PE also as a separate variable
 
-        if dim_emb - dim_pe < 1:
+        if dim_emb - dim_pe < 0: # formerly 1, but you could have zero feature size
             raise ValueError(f"LapPE size {dim_pe} is too large for "
                              f"desired embedding size of {dim_emb}.")
 
-        if expand_x:
+        if expand_x and dim_emb - dim_pe > 0:
             self.linear_x = nn.Linear(dim_in, dim_emb - dim_pe)
-        self.expand_x = expand_x
+        self.expand_x = expand_x and dim_emb - dim_pe > 0
 
         # Initial projection of eigenvalue and the node's eigenvector value
         self.linear_A = nn.Linear(2, dim_pe)

--- a/graphgps/finetuning.py
+++ b/graphgps/finetuning.py
@@ -59,7 +59,7 @@ def load_pretrained_model_cfg(cfg):
     set_new_cfg_allowed(pretrained_cfg, True)
     pretrained_cfg.merge_from_file(pretrained_cfg_fname)
 
-    assert cfg.model.type == 'GPSModel', \
+    assert cfg.model.type in ["GPSModel", "Graphormer"], \
         "Fine-tuning regime is untested for other model types."
     compare_cfg(cfg, pretrained_cfg, 'model.type', strict=True)
     compare_cfg(cfg, pretrained_cfg, 'model.graph_pooling')
@@ -97,7 +97,7 @@ def load_pretrained_model_cfg(cfg):
 
 
 def init_model_from_pretrained(model, pretrained_dir,
-                               freeze_main=False, reset_prediction_head=True):
+                               freeze_main=False, reset_prediction_head=True, seed=0):
     """ Copy model parameters from pretrained model except the prediction head.
 
     Args:
@@ -107,13 +107,14 @@ def init_model_from_pretrained(model, pretrained_dir,
             of the `main body` (train the prediction head only), else train all.
         reset_prediction_head: If True, reset parameters of the prediction head,
             else keep the pretrained weights.
+        seed: Optionally, the training seed
 
     Returns:
         Updated pytorch model object.
     """
     from torch_geometric.graphgym.checkpoint import MODEL_STATE
 
-    ckpt_file = get_final_pretrained_ckpt(osp.join(pretrained_dir, '0', 'ckpt'))
+    ckpt_file = get_final_pretrained_ckpt(osp.join(pretrained_dir, str(seed), 'ckpt'))
     logging.info(f"[*] Loading from pretrained model: {ckpt_file}")
 
     ckpt = torch.load(ckpt_file, map_location=torch.device('cpu'))

--- a/graphgps/head/graphormer_graph.py
+++ b/graphgps/head/graphormer_graph.py
@@ -1,0 +1,37 @@
+import torch
+
+import torch_geometric.graphgym.register as register
+from torch_geometric.graphgym import cfg
+from torch_geometric.graphgym.register import register_head
+
+
+@register_head('graphormer_graph')
+class GraphormerHead(torch.nn.Module):
+    """
+    Graphormer prediction head for graph prediction tasks.
+
+    Args:
+        dim_in (int): Input dimension.
+        dim_out (int): Output dimension. For binary prediction, dim_out=1.
+    """
+
+    def __init__(self, dim_in, dim_out):
+        super().__init__()
+        print(f"Initializing {cfg.model.graph_pooling} pooling function")
+        self.pooling_fun = register.pooling_dict[cfg.model.graph_pooling]
+
+        self.ln = torch.nn.LayerNorm(dim_in)
+        self.layers = torch.nn.Sequential(
+            torch.nn.Linear(dim_in, dim_out)
+        )
+
+    def _apply_index(self, batch):
+        return batch.graph_feature, batch.y
+
+    def forward(self, batch):
+        x = self.ln(batch.x)
+        graph_emb = self.pooling_fun(x, batch.batch)
+        graph_emb = self.layers(graph_emb)
+        batch.graph_feature = graph_emb
+        pred, label = self._apply_index(batch)
+        return pred, label

--- a/graphgps/head/infer_links.py
+++ b/graphgps/head/infer_links.py
@@ -1,0 +1,29 @@
+import torch
+from torch_geometric.graphgym import cfg
+from torch_geometric.graphgym.register import register_head
+
+
+@register_head('infer_links')
+class InferLinksHead(torch.nn.Module):
+    """
+    InferLinks prediction head for graph prediction tasks.
+
+    Args:
+        dim_in (int): Input dimension.
+        dim_out (int): Output dimension. For binary prediction, dim_out=1.
+    """
+
+    def __init__(self, dim_in, dim_out):
+        super().__init__()
+        if cfg.dataset.infer_link_label == "edge":
+            dim_out = 2
+        else:
+            raise ValueError(f"Infer-link task {cfg.dataset.infer_link_label} not available.")
+
+        self.predictor = torch.nn.Linear(1, dim_out)
+
+    def forward(self, batch):
+        x = batch.x[batch.complete_edge_index]
+        x = (x[0] * x[1]).sum(1)
+        y = self.predictor(x.unsqueeze(1))
+        return y, batch.y

--- a/graphgps/layer/graphormer_layer.py
+++ b/graphgps/layer/graphormer_layer.py
@@ -1,0 +1,49 @@
+import torch
+from torch_geometric.utils import to_dense_batch
+
+
+class GraphormerLayer(torch.nn.Module):
+    def __init__(self, embed_dim: int, num_heads: int, dropout: float,
+                 attention_dropout: float, mlp_dropout: float):
+        """Implementation of the Graphormer layer.
+        This layer is based on the implementation at:
+        https://github.com/microsoft/Graphormer/tree/v1.0
+        Note that this refers to v1 of Graphormer.
+
+        Args:
+            embed_dim: The number of hidden dimensions of the model
+            num_heads: The number of heads of the Graphormer model
+            dropout: Dropout applied after the attention and after the MLP
+            attention_dropout: Dropout applied within the attention
+            input_dropout: Dropout applied within the MLP
+        """
+        super().__init__()
+        self.attention = torch.nn.MultiheadAttention(embed_dim,
+                                                     num_heads,
+                                                     attention_dropout,
+                                                     batch_first=True)
+        self.input_norm = torch.nn.LayerNorm(embed_dim)
+        self.dropout = torch.nn.Dropout(dropout)
+
+        # We follow the paper in that all hidden dims are
+        # equal to the embedding dim
+        self.mlp = torch.nn.Sequential(
+            torch.nn.LayerNorm(embed_dim),
+            torch.nn.Linear(embed_dim, embed_dim),
+            torch.nn.GELU(),
+            torch.nn.Dropout(mlp_dropout),
+            torch.nn.Linear(embed_dim, embed_dim),
+            torch.nn.Dropout(dropout),
+        )
+
+    def forward(self, data):
+        x = self.input_norm(data.x)
+        x, real_nodes = to_dense_batch(x, data.batch)
+
+        if hasattr(data, "attn_bias"):
+            x = self.attention(x, x, x, ~real_nodes, attn_mask=data.attn_bias)[0][real_nodes]
+        else:
+            x = self.attention(x, x, x, ~real_nodes)[0][real_nodes]
+        x = self.dropout(x) + data.x
+        data.x = self.mlp(x) + x
+        return data

--- a/graphgps/logger.py
+++ b/graphgps/logger.py
@@ -164,9 +164,9 @@ class CustomLogger(Logger):
                 'auc': reformat(
                     metrics_ogb.eval_rocauc(true, pred_score)['rocauc']),
             }
-            assert np.isclose(ogb['accuracy'], results['accuracy'])
-            assert np.isclose(ogb['ap'], results['ap'])
-            assert np.isclose(ogb['auc'], results['auc'])
+            assert np.isclose(ogb['accuracy'], results['accuracy'], atol=1e-05)
+            assert np.isclose(ogb['ap'], results['ap'], atol=1e-05)
+            assert np.isclose(ogb['auc'], results['auc'], atol=1e-05)
 
         return results
 

--- a/graphgps/network/gps_model.py
+++ b/graphgps/network/gps_model.py
@@ -28,7 +28,7 @@ class FeatureEncoder(torch.nn.Module):
                 self.node_encoder_bn = BatchNorm1dNode(
                     new_layer_config(cfg.gnn.dim_inner, -1, -1, has_act=False,
                                      has_bias=False, cfg=cfg))
-            # Update dim_in to reflect the new dimension fo the node features
+            # Update dim_in to reflect the new dimension of the node features
             self.dim_in = cfg.gnn.dim_inner
         if cfg.dataset.edge_encoder:
             # Hard-limit max edge dim for PNA.
@@ -53,7 +53,10 @@ class FeatureEncoder(torch.nn.Module):
 
 @register_network('GPSModel')
 class GPSModel(torch.nn.Module):
-    """Multi-scale graph x-former.
+    """General-Powerful-Scalable graph transformer.
+    https://arxiv.org/abs/2205.12454
+    Rampasek, L., Galkin, M., Dwivedi, V. P., Luu, A. T., Wolf, G., & Beaini, D.
+    Recipe for a general, powerful, scalable graph transformer. (NeurIPS 2022)
     """
 
     def __init__(self, dim_in, dim_out):
@@ -66,8 +69,12 @@ class GPSModel(torch.nn.Module):
                 dim_in, cfg.gnn.dim_inner, cfg.gnn.layers_pre_mp)
             dim_in = cfg.gnn.dim_inner
 
-        assert cfg.gt.dim_hidden == cfg.gnn.dim_inner == dim_in, \
-            "The inner and hidden dims must match."
+        if not cfg.gt.dim_hidden == cfg.gnn.dim_inner == dim_in:
+            raise ValueError(
+                f"The inner and hidden dims must match: "
+                f"embed_dim={cfg.gt.dim_hidden} dim_inner={cfg.gnn.dim_inner} "
+                f"dim_in={dim_in}"
+            )
 
         try:
             local_gnn_type, global_model_type = cfg.gt.layer_type.split('+')

--- a/graphgps/network/graphormer.py
+++ b/graphgps/network/graphormer.py
@@ -1,0 +1,52 @@
+import torch
+import torch_geometric.graphgym.register as register
+from torch_geometric.graphgym.config import cfg
+from torch_geometric.graphgym.models.gnn import FeatureEncoder, GNNPreMP
+from torch_geometric.graphgym.register import register_network
+
+from graphgps.layer.graphormer_layer import GraphormerLayer
+
+
+@register_network('Graphormer')
+class GraphormerModel(torch.nn.Module):
+    """Graphormer port to GraphGPS.
+    https://arxiv.org/abs/2106.05234
+    Ying, C., Cai, T., Luo, S., Zheng, S., Ke, G., He, D., ... & Liu, T. Y.
+    Do transformers really perform badly for graph representation? (NeurIPS2021)
+    """
+
+    def __init__(self, dim_in, dim_out):
+        super().__init__()
+        self.encoder = FeatureEncoder(dim_in)
+        dim_in = self.encoder.dim_in
+
+        if cfg.gnn.layers_pre_mp > 0:
+            self.pre_mp = GNNPreMP(
+                dim_in, cfg.gnn.dim_inner, cfg.gnn.layers_pre_mp)
+            dim_in = cfg.gnn.dim_inner
+
+        if not cfg.graphormer.embed_dim == cfg.gnn.dim_inner == dim_in:
+            raise ValueError(
+                f"The inner and embed dims must match: "
+                f"embed_dim={cfg.graphormer.embed_dim} "
+                f"dim_inner={cfg.gnn.dim_inner} dim_in={dim_in}"
+            )
+
+        layers = []
+        for _ in range(cfg.graphormer.num_layers):
+            layers.append(GraphormerLayer(
+                embed_dim=cfg.graphormer.embed_dim,
+                num_heads=cfg.graphormer.num_heads,
+                dropout=cfg.graphormer.dropout,
+                attention_dropout=cfg.graphormer.attention_dropout,
+                mlp_dropout=cfg.graphormer.mlp_dropout
+            ))
+        self.layers = torch.nn.Sequential(*layers)
+
+        GNNHead = register.head_dict[cfg.gnn.head]
+        self.post_mp = GNNHead(dim_in=cfg.gnn.dim_inner, dim_out=dim_out)
+
+    def forward(self, batch):
+        for module in self.children():
+            batch = module(batch)
+        return batch

--- a/graphgps/pooling/graph_token.py
+++ b/graphgps/pooling/graph_token.py
@@ -1,0 +1,12 @@
+from torch_geometric.graphgym.register import register_pooling
+from torch_geometric.utils import to_dense_batch
+
+
+@register_pooling('graph_token')
+def graph_token_pooling(x, batch, *args):
+    """Extracts the graph token from a batch to perform graph-level prediction.
+    Typically used together with Graphormer when GraphormerEncoder is used and
+    the global graph token is used: `cfg.graphormer.use_graph_token == True`.
+    """
+    x, _ = to_dense_batch(x, batch)
+    return x[:, 0, :]

--- a/graphgps/train/custom_train.py
+++ b/graphgps/train/custom_train.py
@@ -33,7 +33,8 @@ def train_epoch(logger, loader, model, optimizer, scheduler, batch_accumulation)
         # Parameters update after accumulating gradients for given num. batches.
         if ((iter + 1) % batch_accumulation == 0) or (iter + 1 == len(loader)):
             if cfg.optim.clip_grad_norm:
-                torch.nn.utils.clip_grad_norm_(model.parameters(), 1.0)
+                torch.nn.utils.clip_grad_norm_(model.parameters(),
+                                               cfg.optim.clip_grad_norm_value)
             optimizer.step()
             optimizer.zero_grad()
         logger.update_stats(true=_true,

--- a/graphgps/transform/task_preprocessing.py
+++ b/graphgps/transform/task_preprocessing.py
@@ -1,0 +1,67 @@
+import torch
+
+
+def shuffle(tensor):
+    idx = torch.randperm(len(tensor))
+    return tensor[idx]
+
+
+def task_specific_preprocessing(data, cfg):
+    """Task-specific preprocessing before the dataset is logged and finalized.
+
+    Args:
+        data: PyG graph
+        cfg: Main configuration node
+
+    Returns:
+        Extended PyG Data object.
+    """
+    if cfg.gnn.head == "infer_links":
+        N = data.x.size(0)
+        idx = torch.arange(N, dtype=torch.long)
+        complete_index = torch.stack([idx.repeat_interleave(N), idx.repeat(N)], 0)
+
+        data.edge_attr = None
+        
+        if cfg.dataset.infer_link_label == "edge":
+            labels = torch.empty(N, N, dtype=torch.long)
+            non_edge_index = (complete_index.T.unsqueeze(1) != data.edge_index.T).any(2).all(1).nonzero()[:, 0]
+            non_edge_index = shuffle(non_edge_index)[:data.edge_index.size(1)]
+            edge_index = (complete_index.T.unsqueeze(1) == data.edge_index.T).all(2).any(1).nonzero()[:, 0]
+
+            final_index = shuffle(torch.cat([edge_index, non_edge_index]))
+            data.complete_edge_index = complete_index[:, final_index]
+
+            labels.fill_(0)
+            labels[data.edge_index[0], data.edge_index[1]] = 1
+
+            assert labels.flatten()[final_index].mean(dtype=torch.float) == 0.5
+        else:
+            raise ValueError(f"Infer-link task {cfg.dataset.infer_link_label} not available.")
+
+        data.y = labels.flatten()[final_index]
+
+    supported_encoding_available = (
+        cfg.posenc_LapPE.enable or
+        cfg.posenc_RWSE.enable or
+        cfg.posenc_GraphormerBias.enable
+    )
+
+    if cfg.dataset.name == "TRIANGLES":
+
+        # If encodings are present they can append to the empty data.x
+        if not supported_encoding_available:
+            data.x = torch.zeros((data.x.size(0), 1))
+        data.num_classes = 10
+        data.y = data.y.sub(1).to(torch.long)
+
+    if cfg.dataset.name == "CSL":
+
+        # If encodings are present they can append to the empty data.x
+        if not supported_encoding_available:
+            data.x = torch.zeros((data.num_nodes, 1))
+        else:
+            data.x = torch.zeros((data.num_nodes, 0))
+        data.num_classes = 10
+
+    return data

--- a/main.py
+++ b/main.py
@@ -145,7 +145,7 @@ if __name__ == '__main__':
         if cfg.pretrained.dir:
             model = init_model_from_pretrained(
                 model, cfg.pretrained.dir, cfg.pretrained.freeze_main,
-                cfg.pretrained.reset_prediction_head
+                cfg.pretrained.reset_prediction_head, seed=cfg.seed
             )
         optimizer = create_optimizer(model.parameters(),
                                      new_optimizer_config(cfg))


### PR DESCRIPTION
Four extensions, many thanks to @luis-mueller for spearheading this work!
- `Graphormer` port with model config to reproduce the expected performance on `ZINC`
- `GPS` can be run in a configuration with biased global attention module, i.e., with `Graphormer`-style model
- Added heterophilic transductive dataset support: Actor, Cornell, Texas, Wisconsin, Squirrel, Chameleon
- Added synthetic datasets