### PR TITLE
The graphgps data loader no longer overshadows all other dataloaders.

### DIFF
--- a/graphgps/layer/gatedgcn_layer.py
+++ b/graphgps/layer/gatedgcn_layer.py
@@ -56,8 +56,7 @@ class GatedGCNLayer(pyg_nn.conv.MessagePassing):
 
         Ax = self.A(x)
         Bx = self.B(x)
-        if e is not None:
-            Ce = self.C(e)
+        Ce = self.C(e)
         Dx = self.D(x)
         Ex = self.E(x)
 
@@ -70,35 +69,31 @@ class GatedGCNLayer(pyg_nn.conv.MessagePassing):
                               e=e, Ax=Ax,
                               PE=pe_LapPE)
 
-        
-        if e is not None:
-            e = self.bn_edge_e(e)
-            e = self.act_fn_e(e)
-            e = F.dropout(e, self.dropout, training=self.training)
-
         x = self.bn_node_x(x)
+        e = self.bn_edge_e(e)
+
         x = self.act_fn_x(x)
+        e = self.act_fn_e(e)
+
         x = F.dropout(x, self.dropout, training=self.training)
+        e = F.dropout(e, self.dropout, training=self.training)
 
         if self.residual:
             x = x_in + x
-            if e is not None:
-                e = e_in + e
+            e = e_in + e
 
         batch.x = x
         batch.edge_attr = e
 
         return batch
 
-    def message(self, Dx_i, Ex_j, PE_i, PE_j, Ce=None):
+    def message(self, Dx_i, Ex_j, PE_i, PE_j, Ce):
         """
         {}x_i           : [n_edges, out_dim]
         {}x_j           : [n_edges, out_dim]
         {}e             : [n_edges, out_dim]
         """
-        e_ij = Dx_i + Ex_j
-        if Ce is not None:
-            e_ij = e_ij + Ce
+        e_ij = Dx_i + Ex_j + Ce
         sigma_ij = torch.sigmoid(e_ij)
 
         # Handling for Equivariant and Stable PE using LapPE

--- a/graphgps/loader/master_loader.py
+++ b/graphgps/loader/master_loader.py
@@ -82,10 +82,8 @@ def log_loaded_dataset(dataset, format, name):
 @register_loader('custom_master_loader')
 def load_dataset_master(format, name, dataset_dir):
     """
-    Master loader that controls loading of all datasets, overshadowing execution
-    of any default GraphGym dataset loader. Default GraphGym dataset loader are
-    instead called from this function, the format keywords `PyG` and `OGB` are
-    reserved for these default GraphGym loaders.
+    Master loader that controls loading of all GraphGPS datasets, overshadowing execution
+    of 'OGB' datasets.
 
     Custom transforms and dataset splitting is applied to each loaded dataset.
 
@@ -143,11 +141,6 @@ def load_dataset_master(format, name, dataset_dir):
 
         else:
             raise ValueError(f"Unexpected PyG Dataset identifier: {format}")
-
-    # GraphGym default loader for Pytorch Geometric datasets
-    elif format == 'PyG':
-        dataset = load_pyg(name, dataset_dir)
-
     elif format == 'OGB':
         if name.startswith('ogbg'):
             dataset = preformat_OGB_Graph(dataset_dir, name.replace('_', '-'))
@@ -178,7 +171,7 @@ def load_dataset_master(format, name, dataset_dir):
         else:
             raise ValueError(f"Unsupported OGB(-derived) dataset: {name}")
     else:
-        raise ValueError(f"Unknown data format: {format}")
+        return None # Not a custom graphgps dataset. Fall back to other loaders
 
     pre_transform_in_memory(dataset, partial(task_specific_preprocessing, cfg=cfg))
 


### PR DESCRIPTION
If users want to use graphGPS as a library in their projects the graphgps master dataloader should not overshadow all other dataloaders. Otherwise they can not create new custom graphgym datasets when building on top of the graphgps library.

The `create_dataset` function first checks whether any custom dataset loader function returns a dataset. A custom data loader function is ignored if it returnes None. [See graphgym implementation here](https://github.com/pyg-team/pytorch_geometric/blob/29b20796d9e3fca1662029d1083d508634b7593e/torch_geometric/graphgym/loader.py#L174). Currently the `custom_master_loader` of graphGPS throws a ValueError if the format is not recognised, but this prohibits any user from registering their own data loader function with graphgym. Further it is not necessary to call the default pyg loaders if no customisation is applied, as the `create_dataset` will fallback to them if no custom routine returns a dataset.

This modification still allows the OGB dataset loader to be overwritten because any custom loader is called first (see again the official implementation in graphgym).

After the modification a user can install the graphgps library normaly and add new dataloaders functions, while any graphGPS datasets are still available (if your code has `import graphgps` somewhere and you have the `graphgps` library installed. In my opinion this is how the creators of graphgym intended this to work.

```
from torch_geometric.graphgym.register import register_loader

@register_loader('my_custom_dataset')
def load_dataset_example(format, name, dataset_dir):
    if format == "my_custom_datsets":
        return ds
    else:
        return None
```