### PR TITLE
[FIX] Stable sorting in graphormer encoder

### DIFF
--- a/graphgps/encoder/graphormer_encoder.py
+++ b/graphgps/encoder/graphormer_encoder.py
@@ -201,7 +201,7 @@ def add_graph_token(data, token):
     data.batch = torch.cat(
         [torch.arange(0, B, device=data.x.device, dtype=torch.long), data.batch]
     )
-    data.batch, sort_idx = torch.sort(data.batch, stable=False)
+    data.batch, sort_idx = torch.sort(data.batch, stable=True)
     data.x = data.x[sort_idx]
     return data
 

--- a/graphgps/encoder/graphormer_encoder.py
+++ b/graphgps/encoder/graphormer_encoder.py
@@ -201,7 +201,7 @@ def add_graph_token(data, token):
     data.batch = torch.cat(
         [torch.arange(0, B, device=data.x.device, dtype=torch.long), data.batch]
     )
-    data.batch, sort_idx = torch.sort(data.batch)
+    data.batch, sort_idx = torch.sort(data.batch, stable=False)
     data.x = data.x[sort_idx]
     return data
 


### PR DESCRIPTION
Indeed, the stable sorting was missing on `add_graph_token` in the graphormer encoder. I ran Graphormer on ZINC for 1000 epochs with and without the stable sorting but couldn't find any difference in performance. Anyway, the stable sorting is definitely needed to preserve the original order of node embeddings.

Closes #40.